### PR TITLE
Remove filtering file set.

### DIFF
--- a/distribution/bin.xml
+++ b/distribution/bin.xml
@@ -25,7 +25,6 @@
         <fileSet>
             <directory>scripts</directory>
             <outputDirectory>.</outputDirectory>
-            <filtered>true</filtered>
         </fileSet>
     </fileSets>
 


### PR DESCRIPTION
This was removed, because CAPP which is created after build is erroneous and it could not be opened.

