### PR TITLE
Add 'routing' transport header

### DIFF
--- a/distribution/scripts/jmeter/ei-test.jmx
+++ b/distribution/scripts/jmeter/ei-test.jmx
@@ -33,6 +33,10 @@
               <stringProp name="Header.value">urn:buyStocks</stringProp>
             </elementProp>
             <elementProp name="" elementType="Header">
+              <stringProp name="Header.name">routing</stringProp>
+              <stringProp name="Header.value">xadmin;server1;community#1.0##</stringProp>
+            </elementProp>
+            <elementProp name="" elementType="Header">
               <stringProp name="Header.name">Content-Type</stringProp>
               <stringProp name="Header.value">text/xml</stringProp>
             </elementProp>
@@ -67,6 +71,15 @@
           <stringProp name="HTTPSampler.connect_timeout"></stringProp>
           <stringProp name="HTTPSampler.response_timeout"></stringProp>
         </HTTPSamplerProxy>
+        <hashTree/>
+        <ResponseAssertion guiclass="AssertionGui" testclass="ResponseAssertion" testname="Response Assertion" enabled="true">
+          <collectionProp name="Asserion.test_strings">
+            <stringProp name="49586">200</stringProp>
+          </collectionProp>
+          <stringProp name="Assertion.test_field">Assertion.response_code</stringProp>
+          <boolProp name="Assertion.assume_success">false</boolProp>
+          <intProp name="Assertion.test_type">8</intProp>
+        </ResponseAssertion>
         <hashTree/>
       </hashTree>
     </hashTree>


### PR DESCRIPTION
## Purpose
This header is used in CBRTransportHeaderProxy. Earlier this header was passed as a SOAP header and inside the proxy it checks for a transport header. Because of that proxy throws errors. So changed it into a transport header in jmeter request.